### PR TITLE
修复创建助理后，按钮无法再次点击的问题

### DIFF
--- a/src/App/ViewModels/Components/AssistantDetailViewModel/AssistantDetailViewModel.cs
+++ b/src/App/ViewModels/Components/AssistantDetailViewModel/AssistantDetailViewModel.cs
@@ -168,6 +168,7 @@ public sealed partial class AssistantDetailViewModel : ViewModelBase
         await ChatDataService.AddOrUpdateAssistantAsync(assistant);
         _parentViewModel.RefreshAssistantsCommand.Execute(default);
         Source = null;
+        IsCreateMode = false;
     }
 
     [RelayCommand]


### PR DESCRIPTION
## 描述

因为没有重置 `IsCreateMode` 属性

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
